### PR TITLE
Some bad ideas about whitelisting

### DIFF
--- a/lib/bitbot/configuration.rb
+++ b/lib/bitbot/configuration.rb
@@ -1,6 +1,6 @@
 module Bitbot
   class Configuration
-    cattr_accessor :user_name, :full_name, :webhook_url, :api_token, :redis_connection
+    cattr_accessor :user_name, :full_name, :webhook_url, :api_token, :redis_connection, :whitelist_groups
 
     @@user_name = "bitbot"
     @@full_name = "Bit Bot"
@@ -56,6 +56,33 @@ module Bitbot
     def self.listener(type = Bitbot::Listener::Web, &block)
       @@listeners[type.type_name] = block
     end
+
+    # whitelist
+
+    # By default, any responder without a specified group can use
+    # all commands/responder routes.
+
+    # By adding a group to a responder, i.e.
+    # `group :moderation`
+    # the bot should check a whitelist of to verify the channel name
+    # matches the list of channels in the group's list (taken from
+    # Bitbot configuration).
+
+    cattr_accessor :whitelist_groups, :blacklist_groups
+
+    # Hash of (group => channel name(s)) pairs
+    # ex. { moderation: ['channel1', 'channel2'] }
+
+    @@whitelist_groups = {
+      support: [:friends].freeze,
+      moderation: [:moderation].freeze
+    }
+
+    @@blacklist_groups = {
+      support: [],
+      moderation: []
+    }
+
   end
 
   mattr_accessor :configuration

--- a/lib/bitbot/responder/dsl.rb
+++ b/lib/bitbot/responder/dsl.rb
@@ -12,6 +12,15 @@ module Bitbot
           @category_name = value
         end
 
+        def groups(*values)
+          @groups = values
+        end
+
+        def group(value)
+          @groups = Array(value)
+        end
+
+
         def help(phrase, options = {})
           @command_help ||= []
           @command_help <<= { phrase: phrase, category: @category }.merge(options)

--- a/spec/bitbot/configuration_spec.rb
+++ b/spec/bitbot/configuration_spec.rb
@@ -50,6 +50,15 @@ describe Bitbot::Configuration do
     expect(subject.listeners[:custom_type]).to eq(config)
   end
 
+  context 'groups and whitelisting' do
+    it 'uses a default list of channels per group' do
+      expect(subject.whitelist_groups).to include({support: [:friends]})
+      expect(subject.whitelist_groups).not_to include({moderation: [:support]})
+      expect(subject.whitelist_groups).to include({moderation: [:moderation]})
+      expect(subject.whitelist_groups[:moderation].length).to be 1
+    end
+  end
+
   it "allows configuration using a block" do
     Bitbot.configure do |config|
       config.full_name = "Bits to the Bot"

--- a/spec/bitbot/responder_spec.rb
+++ b/spec/bitbot/responder_spec.rb
@@ -37,6 +37,26 @@ describe Bitbot::Responder do
     it "returns false if there's no route for the message" do
       expect(described_class.responds_to?(message)).to be_falsy
     end
+
+    context "whitelisting" do
+      it "returns false if the route isn't in the whitelist" do
+        described_class.route(:test, /lana/) {}
+        described_class.route(:secure, /LANA/) { 'Secure route' }
+
+        described_class.whitelist = {
+          support: [:all],
+          moderation: [:test]
+        }
+
+        expect(described_class.responds_to?(message)).to be_truthy
+
+        message.channel_name = "moderation-only"
+        message.text = "LANA"
+        binding.pry
+        expect(described_class.responds_to?(message)).to be_falsy
+      end
+    end
+
   end
 
   describe "#respond_to" do


### PR DESCRIPTION
**Only opening a PR for discussion, the actual branch is probably a dead end**

## Probably better to explore multiple bots per app

*Based on Issue #2, attempted (and failed) at implementing white listing.
* This PR is what is left. May be worth continuing to work on, or just burning with :fire: and trying something else.
* Wanted to at least throw it up in case anyone else explores later on.

Hardest part was naming things (duh) and creating sane defaults. The latter, I'm not really sure what to do.
I first tried whitelisting both channels (a list of channel names would go into the config), so that the bot only listened to those channels. Then, the bot would defer to the responder whether all or just some of the routes were available.
I had trouble figuring out what that looked like in the config. Should it mirror the responders (i.e. load up a list of responders, but only load them if an ENV or config flag is set)? Still not sure.

Then tried to simplify with one hash that would contain keys like `:support` and `:moderation`. Each of those would contain a list of channels. Then the bot would check which "level" the message belonged to and compare that with the list of channels. Blech.

Then paired with @jayzes and ended up here, with the idea of a whitelist and blacklist.

Another issue was trying to allow all routes/responders by default, but then not allow messages to go through if they weren't specifically blacklisted.

In the end, the multiple-bot-per-app idea might work best?