### PR TITLE
add github actions as travis replacement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Run tests
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+
+jobs:
+  specs:
+    name: 'run-specs'
+    # skip on [ci skip] and do not run 2 on push and interal PR
+    if: (contains(github.event.commits[0].message, '[ci skip]') == false) &&  (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    continue-on-error: ${{ matrix.allow_failure || false }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.0
+          bundler-cache: true
+
+      - name: run specs
+        run: |
+          bundle exec rake
+
+      # needs the right code climate reporter id
+      # - name: Test & publish code coverage
+      #   uses: paambaati/codeclimate-action@v3.0.0
+      #   env:
+      #     CC_TEST_REPORTER_ID: <code_climate_reporter_id>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 2.6.0
+  - 2.7.5
+  - 3.1.0
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter


### PR DESCRIPTION
Unfortunately travis is letting us down. Added a github action to run the specs. I changed the ruby version to ruby 3.1, for the action to pass the other PR about ruby 3.0 needs to get merged first.

To enable codeclimate one would need to add the reporter-id to the github repository secrets, see the github action yaml file.